### PR TITLE
add Google Chrome browser to requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ $ ffplay -activation_bytes CAFED00D sample.aax
 
 ## Quick Setup
 
-Python 2 is required along with Selenium and ChromeDriver.
+Python 2 is required along with Selenium, ChromeDriver and Google Chrome.
 
 ```
 pip install requests  # use "easy_install" if pip is missing
@@ -38,6 +38,8 @@ pip install requests  # use "easy_install" if pip is missing
 pip install selenium
 
 Download and extract the correct zip file from the https://sites.google.com/a/chromium.org/chromedriver/downloads site to this folder.
+
+Download Google Chrome from https://www.google.com/chrome/ and install it on your computer.
 
 ```
 


### PR DESCRIPTION
I didn't know what Selenium was or how ChromeDriver worked, but it threw me off when I was getting this error while trying to log in:

```
selenium.common.exceptions.WebDriverException: Message: unknown error: cannot find Chrome binary
(Driver info: chromedriver=2.22.397929 (fb72fb249a903a0b1041ea71eb4c8b3fa0d9be5a),platform=Mac OS X 10.11.5 x86_64)
```

Hopefully this addition can help someone else in the future