### PR TITLE
changed chromedriver_path to only the executable name

### DIFF
--- a/audible-activator.py
+++ b/audible-activator.py
@@ -51,7 +51,7 @@ def fetch_activation_bytes(username, password, options):
     if sys.platform == 'win32':
         chromedriver_path = "chromedriver.exe"
     else:
-        chromedriver_path = "./chromedriver"
+        chromedriver_path = "chromedriver"
 
     driver = webdriver.Chrome(chrome_options=opts,
                               executable_path=chromedriver_path)


### PR DESCRIPTION
Hi I don't know if it whas intended but becuse in the README it states to install chromedriver and the code is pointing to a file in current directory. This will break if you have chromedriver only in the repository folder but not in PATH but it will make it work for all other instances.
Im open for criticism if this pull request is silly

Regards Reidar