### PR TITLE
Makes path relative

### DIFF
--- a/audible-activator.py
+++ b/audible-activator.py
@@ -57,7 +57,7 @@ def fetch_activation_bytes(username, password, options):
         if sys.platform == 'win32':
             chromedriver_path = "chromedriver.exe"
         else:
-            chromedriver_path = "./chromedriver"
+            chromedriver_path = "chromedriver"
 
         driver = webdriver.Chrome(chrome_options=opts,
                                   executable_path=chromedriver_path)


### PR DESCRIPTION
Using the ./ at the beginning forces the program to look in the
current directory for the driver. It's much more portable to simply
rely on the PATH variable.