### PR TITLE
Fix for "Message: 'chromedriver' executable needs to be in PATH. Please

### DIFF
--- a/audible-activator.py
+++ b/audible-activator.py
@@ -57,7 +57,7 @@ def fetch_activation_bytes(username, password, options):
         if sys.platform == 'win32':
             chromedriver_path = "chromedriver.exe"
         else:
-            chromedriver_path = "./chromedriver"
+            chromedriver_path = "chromedriver"
 
         driver = webdriver.Chrome(chrome_options=opts,
                                   executable_path=chromedriver_path)


### PR DESCRIPTION
See https://sites.google.com/a/chromium.org/chromedriver/home error on non-Windows OS's.