### PR TITLE
Don't run headless in debug mode

### DIFF
--- a/audible-activator.py
+++ b/audible-activator.py
@@ -30,9 +30,10 @@ def fetch_activation_bytes(username, password, options):
     # Step 0
     opts = webdriver.ChromeOptions()
     opts.add_argument("user-agent=Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; AS; rv:11.0) like Gecko")
-    opts.add_argument('--headless')
     opts.add_argument('--no-sandbox')
     opts.add_argument('--disable-dev-shm-usage')
+    if not options.debug:
+        opts.add_argument('--headless')
 
     # Step 1
     if '@' in username:  # Amazon login using email address


### PR DESCRIPTION
What's the point of a debug mode if you can't see what's going on?

Also, on my end, chromedriver actually doesn't work at all in headless mode. I ended up having to remove `--headless` from the option list to get it to work at all. (But this is a selenium/chromedriver bug, not yours)