### PR TITLE
Updated find_element_by_id to find_element since find_element_by_id is no longer available

### DIFF
--- a/audible-activator.py
+++ b/audible-activator.py
@@ -99,9 +99,9 @@ def fetch_activation_bytes(username, password, options):
         print("[!] Running in DEBUG mode. You will need to login in a semi-automatic way, wait for the login screen to show up ;)")
         time.sleep(32)
     else:
-        search_box = driver.find_element_by_id('ap_email')
+        search_box = driver.find_element('id','ap_email')
         search_box.send_keys(username)
-        search_box = driver.find_element_by_id('ap_password')
+        search_box = driver.find_element('id','ap_password')
         search_box.send_keys(password)
         search_box.submit()
         time.sleep(2)  # give the page some time to load


### PR DESCRIPTION
Updated find_element_by_id to find_element since find_element_by_id is no longer available

This fixes AttributeError: 'WebDriver' object has no attribute 'find_element_by_id'