### PR TITLE
Updated calls to selenium.webdriver.find_element_by_id

### DIFF
--- a/audible-activator.py
+++ b/audible-activator.py
@@ -10,6 +10,7 @@ import binascii
 import requests
 from getpass import getpass
 from selenium import webdriver
+from selenium.webdriver.common.by import By
 from optparse import OptionParser
 
 PY3 = sys.version_info[0] == 3
@@ -99,9 +100,9 @@ def fetch_activation_bytes(username, password, options):
         print("[!] Running in DEBUG mode. You will need to login in a semi-automatic way, wait for the login screen to show up ;)")
         time.sleep(32)
     else:
-        search_box = driver.find_element_by_id('ap_email')
+        search_box = driver.find_element(By.ID, 'ap_email')
         search_box.send_keys(username)
-        search_box = driver.find_element_by_id('ap_password')
+        search_box = driver.find_element(By.ID, 'ap_password')
         search_box.send_keys(password)
         search_box.submit()
         time.sleep(2)  # give the page some time to load


### PR DESCRIPTION
Running the original audible-activator.py script with the Firefox web driver results in the error:

Traceback (most recent call last):
  File "audible-activator.py", line 202, in <module>
    fetch_activation_bytes(username, password, options)
  File "audible-activator.py", line 102, in fetch_activation_bytes
    search_box = driver.find_element_by_id('ap_email')
AttributeError: 'WebDriver' object has no attribute 'find_element_by_id'

I updated these calls to have the intended functionality by importing By from selenium.webdriver.common.by:

search_box = driver.find_element(By.ID, 'ap_email')

