### PR TITLE
Fix deprecated selenium find_element_by_id()

### DIFF
--- a/audible-activator.py
+++ b/audible-activator.py
@@ -11,6 +11,7 @@ import requests
 from getpass import getpass
 from selenium import webdriver
 from optparse import OptionParser
+from selenium.webdriver.common.by import By
 
 PY3 = sys.version_info[0] == 3
 
@@ -99,9 +100,9 @@ def fetch_activation_bytes(username, password, options):
         print("[!] Running in DEBUG mode. You will need to login in a semi-automatic way, wait for the login screen to show up ;)")
         time.sleep(32)
     else:
-        search_box = driver.find_element_by_id('ap_email')
+        search_box = driver.find_element(By.ID, 'ap_email')
         search_box.send_keys(username)
-        search_box = driver.find_element_by_id('ap_password')
+        search_box = driver.find_element(By.ID, 'ap_password')
         search_box.send_keys(password)
         search_box.submit()
         time.sleep(2)  # give the page some time to load


### PR DESCRIPTION
Simple fix, just added `from selenium.webdriver.common.by import By` for `By.ID` and replaced the `find_element_by_id()` calls with `find_element(By.ID, 'param')`