### PR TITLE
Update webdriver.Chrome() and webdriver.find_element() syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ pip install --user selenium
 ```
 
 Download and extract the correct ChromeDriver zip file [from
-here](https://sites.google.com/a/chromium.org/chromedriver/downloads) to this
+here](https://googlechromelabs.github.io/chrome-for-testing/) to this
 folder.
 
 Download Google Chrome from https://www.google.com/chrome/ and install it on

--- a/audible-activator.py
+++ b/audible-activator.py
@@ -10,6 +10,8 @@ import binascii
 import requests
 from getpass import getpass
 from selenium import webdriver
+from selenium.webdriver.chrome.service import Service
+from selenium.webdriver.common.by import By
 from optparse import OptionParser
 
 PY3 = sys.version_info[0] == 3
@@ -88,8 +90,8 @@ def fetch_activation_bytes(username, password, options):
             chromedriver_path = "./chromedriver"
 
 
-        driver = webdriver.Chrome(options=opts,
-                                  executable_path=chromedriver_path)
+        service = Service(executable_path=chromedriver_path)
+        driver = webdriver.Chrome(service=service, options=opts)
 
     query_string = urlencode(payload)
     url = login_url + query_string
@@ -99,9 +101,9 @@ def fetch_activation_bytes(username, password, options):
         print("[!] Running in DEBUG mode. You will need to login in a semi-automatic way, wait for the login screen to show up ;)")
         time.sleep(32)
     else:
-        search_box = driver.find_element_by_id('ap_email')
+        search_box = driver.find_element(By.ID, 'ap_email')
         search_box.send_keys(username)
-        search_box = driver.find_element_by_id('ap_password')
+        search_box = driver.find_element(By.ID, 'ap_password')
         search_box.send_keys(password)
         search_box.submit()
         time.sleep(2)  # give the page some time to load


### PR DESCRIPTION
selenium.webdriver.Chrome() no longer supports passing executable_path directly. It's now passed via a service. Also, update deprecated calls to find_element_by_id() to the new find_element() method.

Other PRs have already solved half of this but they've not been merged. I also updated the download link for chromedriver.